### PR TITLE
Add support for backtick (raw string) shortcode parameters

### DIFF
--- a/syntaxes/hugo.tmLanguage.json
+++ b/syntaxes/hugo.tmLanguage.json
@@ -56,6 +56,15 @@
                             }
                         },
                         {
+                            "match": "`([^`]+)`",
+                            "name": "support.function.hugo.paraminfo",
+                            "captures": {
+                                "1": {
+                                    "name": "markup.italic.markdown"
+                                }
+                            }
+                        },
+                        {
                             "match": "([\\w\\d/._]+)",
                             "name": "support.function.hugo.main",
                             "captures": {


### PR DESCRIPTION
This enables highlighting of backtick parameters.
- https://gohugo.io/content-management/shortcodes/#shortcodes-with-raw-string-parameters

Unfortunately there is still a preexisting problem -- regexes don't account for strings that may contain escaped quotes.
I tried this:
- https://stackoverflow.com/questions/249791/regex-for-quoted-string-with-escaping-quotes

But it broke something else, so just the backtick support is already good enough for now.

Thanks for your plugin.